### PR TITLE
Fixes ambiguity warning at deps call

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Tackle.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
   def application do
     [ applications: [:logger, :amqp],


### PR DESCRIPTION
In Elixir 1.5.1, a warning is generated for the deps/0 call in Mixfile.project/0:

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
```

This just adds parentheses to the call to remove any ambiguity and squelch the warning.